### PR TITLE
Fix/#47 lists should be inset relative to paragraphs

### DIFF
--- a/public/assets/css/site/components/blog.css
+++ b/public/assets/css/site/components/blog.css
@@ -10,6 +10,17 @@
   }
 }
 
+.c-blog-text ul,
+.c-blog-text ol {
+  margin-left: 0;
+  padding-left: 0;
+  list-style-position: inside;
+}
+
+.c-blog-text li {
+  margin-left: 1.5em;
+}
+
 .c-blog-list {
   margin-top: 1rem;
 


### PR DESCRIPTION
## Beschreibung

<!-- Was wurde geaendert und warum? -->
Lists in Textblocks are now aligned with the rest of the text block 

## Art der Aenderung

- [x] Bug Fix
- [ ] Neues Feature
- [ ] Refactoring (keine funktionale Änderung)
- [x] Style / Design
- [ ] Dokumentation
- [ ] Sonstiges

## Betroffener Bereich

- [ ] Startseite
- [ ] Projekte
- [ ] Raeume / Buchung
- [ ] Newsletter
- [ ] Veranstaltungen
- [ ] Team
- [ ] Blog / Notizen
- [ ] Panel (Verwaltung)
- [x] Design System / CSS
- [ ] Plugin (gs-mmh-web-plugin)
- [ ] Konfiguration / Infrastruktur

## Checkliste

- [ ] Code ist formatiert (`npm run format`)
- [ ] Lint-Checks bestehen (`npm run lint`)
- [x] Änderungen sind lokal getestet
- [x] Desktop und Mobil geprüft
- [x] Keine Konsolenfehler im Browser
- [x] Panel-Funktionen sind nicht beeintraechtigt

## Screenshots

<!-- Falls visuelle Aenderungen: Vorher/Nachher Screenshots einfuegen -->
Before:
<img width="797" height="418" alt="image" src="https://github.com/user-attachments/assets/a2a9bc92-905b-4ac4-ab6b-2e1c86a47881" />

After:
<img width="784" height="385" alt="image" src="https://github.com/user-attachments/assets/5a9866fb-0493-45e2-a5ea-307e9eb5ff5c" />


## Verwandtes Issue

<!-- z.B. Closes #123 -->
Closes #47 