### PR TITLE
form only as block

### DIFF
--- a/site/blueprints/pages/project.yml
+++ b/site/blueprints/pages/project.yml
@@ -71,8 +71,6 @@ columns:
           - cta
           - form
 
-      form: dreamform/fields/form
-
       team:
         type: pages
         label: Team


### PR DESCRIPTION
## Beschreibung

<!-- Was wurde geändert und warum? -->
Form als page von früherer Implementierung in project panel entfernen.
Die Einbindung von forms ist nur noch als block möglich.

## Art der Änderung

- [x] Bug Fix
- [ ] Neues Feature
- [ ] Refactoring (keine funktionale Änderung)
- [ ] Style / Design
- [ ] Dokumentation
- [ ] Sonstiges

## Betroffener Bereich

- [ ] Startseite
- [x] Projekte
- [ ] Räume / Buchung
- [ ] Newsletter
- [ ] Veranstaltungen
- [ ] Team
- [ ] Blog / Notizen
- [ ] Panel (Verwaltung)
- [ ] Design System / CSS
- [ ] Plugin (gs-mmh-web-plugin)
- [ ] Konfiguration / Infrastruktur

## Checkliste

- [ ] Code ist formatiert (`npm run format`)
- [ ] Lint-Checks bestehen (`npm run lint`)
- [ ] Änderungen sind lokal getestet
- [ ] Desktop und Mobil geprüft
- [ ] Keine Konsolenfehler im Browser
- [ ] Panel-Funktionen sind nicht beeintraechtigt

## Screenshots

<!-- Falls visuelle Änderungen: Vorher/Nachher Screenshots einfügen -->

## Verwandtes Issue

<!-- z.B. Closes #123 -->
Closes #84 
