### PR TITLE
Fix author image representation on /notes

### DIFF
--- a/public/assets/css/site/components/notes.css
+++ b/public/assets/css/site/components/notes.css
@@ -102,6 +102,7 @@
    ========================================================================== */
 
 .note-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   background: var(--color-bg-primary, #fff);
@@ -149,6 +150,16 @@
   display: flex;
   align-items: center;
   z-index: 2;
+}
+
+.note-card--no-image .note-card-image-wrapper {
+  position: static;
+}
+
+.note-card--no-image .note-card-authors {
+  top: var(--spacing-3, 1rem);
+  bottom: auto;
+  transform: none;
 }
 
 .note-card-author {
@@ -204,6 +215,11 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+}
+
+.note-card--no-image .note-card-content {
+  padding-top: var(--spacing-5, 2rem);
+  padding-right: calc(var(--spacing-3, 1rem) + 48px);
 }
 
 .note-card-meta {

--- a/site/snippets/content-types/notes/noteCard.php
+++ b/site/snippets/content-types/notes/noteCard.php
@@ -9,10 +9,11 @@
 
 $featured = $featured ?? false;
 $authors = $note->author()->toPages();
+$cover = $note->cover();
 ?>
 
-<article class="note-card <?= $featured ? 'note-card--featured' : '' ?>">
-  <?php if ($featured && ($cover = $note->cover())) : ?>
+<article class="note-card <?= $featured ? 'note-card--featured' : '' ?><?= !$cover ? ' note-card--no-image' : '' ?>">
+  <?php if ($featured && $cover) : ?>
     <!-- Featured Card with Large Image -->
     <div class="note-card-featured">
       <div class="note-card-image-wrapper">
@@ -70,8 +71,8 @@ $authors = $note->author()->toPages();
     </div>
   <?php else : ?>
     <!-- Regular Card -->
-    <div class="note-card-image-wrapper">
-      <?php if ($cover = $note->cover()) : ?>
+    <div class="note-card-image-wrapper <?= $cover ? 'note-card-image-wrapper--has-image' : 'note-card-image-wrapper--no-image' ?>">
+      <?php if ($cover) : ?>
         <a href="<?= $note->url() ?>" class="note-card-image-link">
           <img src="<?= $cover->crop(600, 400)->url() ?>"
                alt="<?= $note->title()->html() ?>"


### PR DESCRIPTION
## Beschreibung

<!-- Was wurde geändert und warum? -->
Fixes to close issue #105 

## Art der Änderung

- [x] Bug Fix
- [ ] Neues Feature
- [ ] Refactoring (keine funktionale Änderung)
- [ ] Style / Design
- [ ] Dokumentation
- [ ] Sonstiges

## Betroffener Bereich

- [ ] Startseite
- [ ] Projekte
- [ ] Räume / Buchung
- [ ] Newsletter
- [ ] Veranstaltungen
- [ ] Team
- [x] Blog / Notizen
- [ ] Panel (Verwaltung)
- [ ] Design System / CSS
- [ ] Plugin (gs-mmh-web-plugin)
- [ ] Konfiguration / Infrastruktur

## Checkliste

- [x] Code ist formatiert (`npm run format`)
- [x] Lint-Checks bestehen (`npm run lint`)
- [x] Änderungen sind lokal getestet
- [x] Desktop und Mobil geprüft
- [x] Keine Konsolenfehler im Browser
- [x] Panel-Funktionen sind nicht beeintraechtigt

## Screenshots

<!-- Falls visuelle Änderungen: Vorher/Nachher Screenshots einfügen -->
<img width="1376" height="591" alt="image" src="https://github.com/user-attachments/assets/992d3992-e479-4e13-b3ed-5e39c271ec1a" />


## Verwandtes Issue

<!-- z.B. Closes #123 -->
Closes #105 