### PR TITLE
refactor: update image cropping method to use boolean for focus cropping

### DIFF
--- a/site/controllers/api-images.php
+++ b/site/controllers/api-images.php
@@ -15,7 +15,7 @@ if (!function_exists('mmhApiJpegImageUrl')) {
             return $file->thumb([
                 'width' => 1200,
                 'height' => 630,
-                'crop' => 'focus',
+                'crop' => true,
                 'format' => 'jpg',
                 'quality' => 88,
             ])->url();

--- a/site/snippets/content-types/newsletter/newsletterItem.php
+++ b/site/snippets/content-types/newsletter/newsletterItem.php
@@ -31,7 +31,7 @@ if ($heroImage && !$heroImage->exists()) {
 <li class="c-newsletterTeaserCard grid-item <?= $class ?>" data-span="1/4">
   <div>
     <?php if ($heroImage && $heroImage->isNotEmpty()) : ?>
-        <?php $url = $heroImage->crop(800, 400, 'focus')->url(); ?>
+        <?php $url = $heroImage->crop(800, 400)->url(); ?>
       <img class="hero" src="<?= $url ?>" alt="<?= $newsletter->title()->html() ?>" loading="lazy">
     <?php else : ?>
       <img class="hero" src="https://picsum.photos/800/400?random=newsletter" alt="<?= $newsletter->title()->html() ?>" loading="lazy">

--- a/site/snippets/content-types/notes/noteCard.php
+++ b/site/snippets/content-types/notes/noteCard.php
@@ -18,7 +18,7 @@ $cover = $note->cover();
     <div class="note-card-featured">
       <div class="note-card-image-wrapper">
         <a href="<?= $note->url() ?>" class="note-card-image-link">
-          <img src="<?= $cover->crop(1200, 500, 'focus')->url() ?>"
+          <img src="<?= $cover->crop(1200, 500)->url() ?>"
                alt="<?= $note->title()->html() ?>"
                class="note-card-image"
                loading="lazy">
@@ -30,7 +30,7 @@ $cover = $note->cover();
             <?php foreach ($authors->limit(2) as $author) : ?>
               <a href="<?= $author->url() ?>" class="note-card-author" title="<?= $author->title()->html() ?>">
                 <?php if ($authorImage = $author->cover()) : ?>
-                  <img src="<?= $authorImage->crop(48, 48, 'focus')->url() ?>" alt="<?= $author->title()->html() ?>">
+                  <img src="<?= $authorImage->crop(48, 48)->url() ?>" alt="<?= $author->title()->html() ?>">
                 <?php else : ?>
                   <span class="placeholder-avatar-small"><?= strtoupper(substr($author->title()->value(), 0, 1)) ?></span>
                 <?php endif ?>
@@ -74,7 +74,7 @@ $cover = $note->cover();
     <div class="note-card-image-wrapper <?= $cover ? 'note-card-image-wrapper--has-image' : 'note-card-image-wrapper--no-image' ?>">
       <?php if ($cover) : ?>
         <a href="<?= $note->url() ?>" class="note-card-image-link">
-          <img src="<?= $cover->crop(600, 400, 'focus')->url() ?>"
+          <img src="<?= $cover->crop(600, 400)->url() ?>"
                alt="<?= $note->title()->html() ?>"
                class="note-card-image"
                loading="lazy">
@@ -86,7 +86,7 @@ $cover = $note->cover();
             <?php foreach ($authors->limit(2) as $author) : ?>
             <a href="<?= $author->url() ?>" class="note-card-author" title="<?= $author->title()->html() ?>">
                 <?php if ($authorImage = $author->cover()) : ?>
-                <img src="<?= $authorImage->crop(40, 40, 'focus')->url() ?>" alt="<?= $author->title()->html() ?>">
+                <img src="<?= $authorImage->crop(40, 40)->url() ?>" alt="<?= $author->title()->html() ?>">
                 <?php else : ?>
                 <span class="placeholder-avatar-small"><?= strtoupper(substr($author->title()->value(), 0, 1)) ?></span>
                 <?php endif ?>

--- a/site/snippets/content-types/rooms/bookingForm.php
+++ b/site/snippets/content-types/rooms/bookingForm.php
@@ -35,7 +35,7 @@ $maxDate = date('Y-m-d', strtotime("+{$maxFuture} days"));
                  class="room-checkbox">
           <span class="room-checkbox-content">
             <?php if ($cover = $room->cover()) : ?>
-              <img src="<?= $cover->crop(120, 80, 'focus')->url() ?>" alt="<?= $room->title()->html() ?>" class="room-checkbox-image">
+              <img src="<?= $cover->crop(120, 80)->url() ?>" alt="<?= $room->title()->html() ?>" class="room-checkbox-image">
             <?php endif ?>
             <span class="room-checkbox-info">
               <span class="room-checkbox-title font-body"><?= $room->title()->html() ?></span>

--- a/site/snippets/content-types/rooms/roomCard.php
+++ b/site/snippets/content-types/rooms/roomCard.php
@@ -12,7 +12,7 @@
     <!-- Image -->
     <div class="room-card-image-wrapper">
       <?php if ($cover = $room->cover()) : ?>
-        <img src="<?= $cover->crop(600, 400, 'focus')->url() ?>"
+        <img src="<?= $cover->crop(600, 400)->url() ?>"
              alt="<?= $room->title()->html() ?>"
              class="room-card-image"
              loading="lazy">

--- a/site/snippets/content-types/team/teamMemberCard.php
+++ b/site/snippets/content-types/team/teamMemberCard.php
@@ -9,7 +9,7 @@
     <a href="<?= $teamMember->url() ?>" >
   <div class="profile-image">
     <?php if ($teamMember->cover() && $teamMember->cover()->toFile()) : ?>
-      <img src="<?= $teamMember->cover()->crop(200, 200, 'focus')->url() ?>"
+      <img src="<?= $teamMember->cover()->crop(200, 200)->url() ?>"
            alt="<?= $teamMember->name()->html() ?>" 
            loading="lazy">
     <?php else : ?>

--- a/site/snippets/sections/hero.php
+++ b/site/snippets/sections/hero.php
@@ -12,7 +12,7 @@ $heroImages = $page->cover(); // check if cover() exists and then run the toFile
 
     <?php // instead of getting pictures from here, use the images of the field "hero" of each page?>
     <?php if ($heroImages && $heroImages->isNotEmpty()) : ?>
-            <img src="<?= $heroImages->thumb(['width' => 1600, 'height' => 800, 'quality' => 80, 'crop' => 'focus'])->url() ?>" alt="<?= $heroImages->alt() ?>">
+            <img src="<?= $heroImages->thumb(['width' => 1600, 'height' => 800, 'quality' => 80, 'crop' => true])->url() ?>" alt="<?= $heroImages->alt() ?>">
 
     <?php else : ?>
         <img src="<?= $url ?? 'https://picsum.photos/1600/800?' ?>" alt="Ein zufällig ausgewähltes Bild">

--- a/site/templates/member.php
+++ b/site/templates/member.php
@@ -25,7 +25,7 @@
           <div class="contact-profile-section">
             <div class="profile-image-large">
               <?php if ($page->cover() && $page->cover()->toFile()) : ?>
-                <img src="<?= $page->cover()->crop(300, 300, 'focus')->url() ?>"
+                <img src="<?= $page->cover()->crop(300, 300)->url() ?>"
                      alt="<?= $page->name()->html() ?>"
                      loading="eager">
               <?php else : ?>

--- a/site/templates/note.php
+++ b/site/templates/note.php
@@ -18,7 +18,7 @@ $blockIsVisible = require kirby()->root('controllers') . '/blocks.php';
     <?php if ($cover = $page->cover()) : ?>
       <section class="note-hero">
         <div class="note-hero-image">
-          <img src="<?= $cover->crop(1920, 800, 'focus')->url() ?>"
+          <img src="<?= $cover->crop(1920, 800)->url() ?>"
             alt="<?= $page->title()->html() ?>"
             loading="eager">
           <div class="note-hero-overlay"></div>
@@ -82,7 +82,7 @@ if ($authors->count() > 0) :
               <a href="<?= $author->url() ?>" class="author-card">
                 <div class="author-avatar">
                   <?php if ($authorImage = $author->cover()) : ?>
-                    <img src="<?= $authorImage->crop(80, 80, 'focus')->url() ?>" alt="<?= $author->title()->html() ?>">
+                    <img src="<?= $authorImage->crop(80, 80)->url() ?>" alt="<?= $author->title()->html() ?>">
                   <?php else : ?>
                     <div class="placeholder-avatar">
                       <span><?= strtoupper(substr($author->title()->value(), 0, 1)) ?></span>

--- a/site/templates/notes.php
+++ b/site/templates/notes.php
@@ -13,7 +13,7 @@
   <section class="notes-hero">
     <?php if ($cover = $page->cover()) : ?>
       <div class="notes-hero-image">
-        <img src="<?= $cover->crop(1920, 600, 'focus')->url() ?>"
+        <img src="<?= $cover->crop(1920, 600)->url() ?>"
              alt="<?= $page->title()->html() ?>"
              loading="eager">
         <div class="notes-hero-overlay"></div>

--- a/site/templates/project.php
+++ b/site/templates/project.php
@@ -86,7 +86,7 @@
               <a href="<?= $member->url() ?>" class="project-team-member" title="<?= $member->title()->html() ?>">
                 <span class="project-team-avatar">
                   <?php if ($memberImage = $member->cover()) : ?>
-                    <img src="<?= $memberImage->crop(160, 160, 'focus')->url() ?>" alt="<?= $member->title()->html() ?>">
+                    <img src="<?= $memberImage->crop(160, 160)->url() ?>" alt="<?= $member->title()->html() ?>">
                   <?php else : ?>
                     <span class="project-team-placeholder">
                       <?= strtoupper(substr($member->title()->value(), 0, 1)) ?>

--- a/site/templates/room.php
+++ b/site/templates/room.php
@@ -57,7 +57,7 @@ $allRooms = $roomsPage->children()->listed();
     <div class="grid-item" data-span="1/1">
       <?php if ($cover = $page->cover()->toFile()) : ?>
         <div class="room-main-image">
-          <img src="<?= $cover->crop(1200, 600, 'focus')->url() ?>"
+          <img src="<?= $cover->crop(1200, 600)->url() ?>"
                alt="<?= $page->title()->html() ?>"
                loading="eager">
         </div>
@@ -68,7 +68,7 @@ $allRooms = $roomsPage->children()->listed();
         <div class="room-gallery">
             <?php foreach ($gallery as $image) : ?>
             <a href="<?= $image->url() ?>" class="room-gallery-item" data-lightbox="room-gallery">
-              <img src="<?= $image->crop(300, 200, 'focus')->url() ?>"
+              <img src="<?= $image->crop(300, 200)->url() ?>"
                    alt="<?= $image->alt()->or($page->title()) ?>"
                    loading="lazy">
             </a>
@@ -201,7 +201,7 @@ $allRooms = $roomsPage->children()->listed();
               <li class="other-room-item">
                 <a href="<?= $otherRoom->url() ?>" class="other-room-link">
                   <?php if ($otherCover = $otherRoom->cover()->toFile()) : ?>
-                    <img src="<?= $otherCover->crop(80, 60, 'focus')->url() ?>"
+                    <img src="<?= $otherCover->crop(80, 60)->url() ?>"
                          alt="<?= $otherRoom->title()->html() ?>"
                          class="other-room-thumb">
                   <?php endif ?>

--- a/site/templates/rooms.php
+++ b/site/templates/rooms.php
@@ -15,7 +15,7 @@ $blockIsVisible = require kirby()->root('controllers') . '/blocks.php';
   <section class="rooms-hero">
     <?php if ($page->cover() && $cover = $page->cover()->toFile()) : ?>
       <div class="rooms-hero-image">
-        <img src="<?= $cover->crop(1920, 600, 'focus')->url() ?>"
+        <img src="<?= $cover->crop(1920, 600)->url() ?>"
           alt="<?= $page->title()->html() ?>"
           loading="eager">
         <div class="rooms-hero-overlay"></div>


### PR DESCRIPTION
## Beschreibung

->crop(1200, 600, "focus") wurden als fix vor Kirby 5.4.4 eingeführt. Dieses ist nun nativ. Rückbau hiermit erfolgt.

## Art der Änderung

- [x] Bug Fix
- [ ] Neues Feature
- [x] Refactoring (keine funktionale Änderung)
- [ ] Style / Design
- [ ] Dokumentation
- [ ] Sonstiges

## Betroffener Bereich

- [x] Startseite
- [x] Projekte
- [x] Räume / Buchung
- [x] Newsletter
- [x] Veranstaltungen
- [x] Team
- [x] Blog / Notizen
- [ ] Panel (Verwaltung)
- [ ] Design System / CSS
- [ ] Plugin (gs-mmh-web-plugin)
- [ ] Konfiguration / Infrastruktur

## Checkliste

- [x] Code ist formatiert (`npm run format`)
- [x] Lint-Checks bestehen (`npm run lint`)
- [x] Änderungen sind lokal getestet
- [x] Desktop und Mobil geprüft
- [x] Keine Konsolenfehler im Browser
- [x] Panel-Funktionen sind nicht beeintraechtigt

## Screenshots

###Vorher
<img width="1125" height="625" alt="Bildschirmfoto 2026-07-02 um 19 34 16" src="https://github.com/user-attachments/assets/a8fc3cd6-9100-42dd-910f-80c3f7a86f15" />
### Nachher
<img width="857" height="489" alt="Bildschirmfoto 2026-07-02 um 19 34 48" src="https://github.com/user-attachments/assets/7c2dd2c7-7dda-46bb-aacf-4e59251d8397" />


## Verwandtes Issue
